### PR TITLE
Update UI.xaml.cs

### DIFF
--- a/ESAPI/Projects/VMATTBIautoPlan/UI.xaml.cs
+++ b/ESAPI/Projects/VMATTBIautoPlan/UI.xaml.cs
@@ -1694,7 +1694,7 @@ namespace VMATTBIautoPlan
                                         line = cropLine(line, "{");
                                         linac_temp.Add(line.Substring(0, line.IndexOf("}")));
                                     }
-                                    else if (line.Contains("add energy"))
+                                    else if (line.Contains("add beam energy"))
                                     {
                                         //parse the photon energies that should be added. One entry per line
                                         line = cropLine(line, "{");


### PR DESCRIPTION
Bug reported by SA at UPMC where changes were made to the available beam energies in the configuration file, but the default 6X and 10X energies would still show up.